### PR TITLE
paper-styles no longer has x-paper-styles.html

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "polymer": "Polymer/polymer#0.8-preview",
     "layout": "Polymer/layout",
-    "paper-styles": "PolymerLabs/paper-styles"
+    "paper-styles": "PolymerElements/paper-styles#^0.8.0"
   },
   "devDependencies": {
     "webcomponentsjs": "Polymer/webcomponentsjs",

--- a/paper-item.html
+++ b/paper-item.html
@@ -10,7 +10,7 @@
 
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../layout/x-layout.html">
-<link rel="import" href="../paper-styles/x-paper-styles.html">
+<link rel="import" href="../paper-styles/paper-styles.html">
 
 <!--
 `paper-item` is a non-interactive list item.


### PR DESCRIPTION
It's been removed, looks like. This was causing vulcanize build errors when importing paper-item.