### PR TITLE
correct stylesheet import

### DIFF
--- a/paper-icon-item.html
+++ b/paper-icon-item.html
@@ -17,7 +17,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <dom-module id="paper-icon-item">
 
-  <link rel="import" type="css" href="paper-item-shared.css">
+  <link rel="stylesheet" type="text/css" href="paper-item-shared.css">
 
   <style>
 


### PR DESCRIPTION
using link for stylesheets should use `rel='stylesheet'` not `rel='import'`. The default mime type for import is text/html and this can also cause issue with some preprocessors.