### PR TITLE
Fix off-center contents in IE

### DIFF
--- a/paper-item-body.html
+++ b/paper-item-body.html
@@ -28,10 +28,12 @@ three- line items.
 
     :host([two-line]) {
       min-height: 72px;
+      height: 72px;
     }
 
     :host([three-line]) {
       min-height: 88px;
+      height: 88px;
     }
 
     :host > ::content > * {

--- a/paper-item-shared.css
+++ b/paper-item-shared.css
@@ -11,6 +11,7 @@
 :host {
   display: block;
   min-height: 48px;
+  height: 48px;
   padding: 0px 16px;
 }
 


### PR DESCRIPTION
Another day, another style bug in IE.

**Chrome, working OK** | **IE being a silly willy** | **After patch**
------------------ | ---------------- | ------------------
![chrome-paper-item](https://cloud.githubusercontent.com/assets/9868643/7698873/9080c252-fdc8-11e4-829d-a36a4599e74e.png) | ![ie-paper-item-broken](https://cloud.githubusercontent.com/assets/9868643/7698874/9081d642-fdc8-11e4-997e-85c425986b6b.png) | ![ie-paper-item-fixed](https://cloud.githubusercontent.com/assets/9868643/7698875/90858210-fdc8-11e4-9e74-2d721058f788.png)

