### PR TITLE
fix a11y issues

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -31,10 +31,11 @@
     "iron-icon": "PolymerElements/iron-icon#^1.0.0",
     "iron-icons": "PolymerElements/iron-icons#^1.0.0",
     "paper-checkbox": "PolymerElements/paper-checkbox#^1.0.0",
+    "paper-icon-button": "PolymerElements/paper-icon-button#^1.0.0",
     "paper-toggle-button": "PolymerElements/paper-toggle-button#^1.0.0",
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
     "test-fixture": "PolymerElements/test-fixture#^1.0.0",
-    "web-component-tester": "*",
+    "web-component-tester": "Polymer/web-component-tester#^3.3.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
   }
 }

--- a/demo/index.html
+++ b/demo/index.html
@@ -23,6 +23,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <link rel="import" href="../../iron-icons/iron-icons.html">
   <link rel="import" href="../../iron-icons/communication-icons.html">
   <link rel="import" href="../../paper-checkbox/paper-checkbox.html">
+  <link rel="import" href="../../paper-icon-button/paper-icon-button.html">
   <link rel="import" href="../../paper-toggle-button/paper-toggle-button.html">
   <link rel="import" href="../paper-icon-item.html">
   <link rel="import" href="../paper-item.html">
@@ -77,27 +78,27 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <div class="layout wrap inline center-center">
     <div>
       <h4>Single line items</h4>
-      <div class="list short">
-        <paper-item>Inbox</paper-item>
-        <paper-item>Starred</paper-item>
-        <paper-item>Sent mail</paper-item>
-        <paper-item>Drafts</paper-item>
+      <div class="list short" role="list">
+        <paper-item tabindex="0">Inbox</paper-item>
+        <paper-item tabindex="0">Starred</paper-item>
+        <paper-item tabindex="0">Sent mail</paper-item>
+        <paper-item tabindex="0">Drafts</paper-item>
       </div>
     </div>
 
     <div>
       <h4>Icon with text</h4>
-      <div class="list short">
-        <paper-icon-item>
+      <div class="list short" role="list">
+        <paper-icon-item tabindex="0">
           <iron-icon icon="inbox" item-icon></iron-icon> Inbox
         </paper-icon-item>
-        <paper-icon-item>
+        <paper-icon-item tabindex="0">
           <iron-icon icon="send" item-icon></iron-icon> Outbox
         </paper-icon-item>
-        <paper-icon-item>
+        <paper-icon-item tabindex="0">
           <iron-icon icon="delete" item-icon></iron-icon> Trash
         </paper-icon-item>
-        <paper-icon-item>
+        <paper-icon-item tabindex="0">
         <iron-icon icon="report" item-icon></iron-icon> Spam
       </paper-icon-item>
       </div>
@@ -105,17 +106,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <div>
       <h4>Avatar with text</h4>
-      <div class="list short">
-        <paper-icon-item>
+      <div class="list short" role="list">
+        <paper-icon-item tabindex="0">
           <div class="avatar blue" item-icon></div> Alphonso Engelking
         </paper-icon-item>
-        <paper-icon-item>
+        <paper-icon-item tabindex="0">
           <div class="avatar red" item-icon></div> Andrews Boyd
         </paper-icon-item>
-        <paper-icon-item>
+        <paper-icon-item tabindex="0">
           <div class="avatar orange" item-icon></div> Angela Decker
         </paper-icon-item>
-        <paper-icon-item>
+        <paper-icon-item tabindex="0">
           <div class="avatar green" item-icon></div> Lorem Ipsum
         </paper-icon-item>
       </div>
@@ -123,23 +124,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <div>
       <h4>Avatar with text and icon</h4>
-      <div class="list short">
-        <paper-icon-item>
+      <div class="list short" role="list">
+        <paper-icon-item tabindex="0">
           <div class="avatar red" item-icon></div>
           <div class="flex">Alphonso</div>
           <iron-icon icon="communication:chat"></iron-icon>
         </paper-icon-item>
-        <paper-icon-item>
+        <paper-icon-item tabindex="0">
           <div class="avatar orange" item-icon></div>
           <div class="flex">Andrews</div>
           <iron-icon icon="communication:chat"></iron-icon>
         </paper-icon-item>
-        <paper-icon-item>
+        <paper-icon-item tabindex="0">
           <div class="avatar green" item-icon></div>
           <div class="flex">Angela</div>
           <iron-icon icon="communication:chat"></iron-icon>
         </paper-icon-item>
-        <paper-icon-item>
+        <paper-icon-item tabindex="0">
           <div class="avatar blue" item-icon></div>
           <div class="flex">Lorem</div>
           <iron-icon icon="communication:chat"></iron-icon>
@@ -149,23 +150,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <div>
       <h4>Avatar with text and control</h4>
-      <div class="list short">
-        <paper-icon-item>
+      <div class="list short" role="list">
+        <paper-icon-item tabindex="0">
           <div class="avatar orange" item-icon></div>
           <div class="flex">Alphonso</div>
           <paper-checkbox></paper-checkbox>
         </paper-icon-item>
-        <paper-icon-item>
+        <paper-icon-item tabindex="0">
           <div class="avatar green" item-icon></div>
           <div class="flex">Andrews</div>
           <paper-checkbox checked></paper-checkbox>
         </paper-icon-item>
-        <paper-icon-item>
+        <paper-icon-item tabindex="0">
           <div class="avatar blue" item-icon></div>
           <div class="flex">Angela</div>
           <paper-checkbox></paper-checkbox>
         </paper-icon-item>
-        <paper-icon-item>
+        <paper-icon-item tabindex="0">
           <div class="avatar red" item-icon></div>
           <div class="flex">Lorem</div>
           <paper-checkbox></paper-checkbox>
@@ -175,23 +176,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <div>
       <h4>Control with text and icon</h4>
-      <div class="list short">
-        <paper-icon-item>
+      <div class="list short" role="list">
+        <paper-icon-item tabindex="0">
           <paper-checkbox item-icon></paper-checkbox>
           <div class="flex">Alphonso</div>
           <iron-icon icon="communication:chat"></iron-icon>
         </paper-icon-item>
-        <paper-icon-item>
+        <paper-icon-item tabindex="0">
           <paper-checkbox checked item-icon></paper-checkbox>
           <div class="flex">Andrews</div>
           <iron-icon icon="communication:chat"></iron-icon>
         </paper-icon-item>
-        <paper-icon-item>
+        <paper-icon-item tabindex="0">
           <paper-checkbox item-icon></paper-checkbox>
           <div class="flex">Angela</div>
           <iron-icon icon="communication:chat"></iron-icon>
         </paper-icon-item>
-        <paper-icon-item>
+        <paper-icon-item tabindex="0">
           <paper-checkbox item-icon></paper-checkbox>
           <div class="flex">Lorem</div>
           <iron-icon icon="communication:chat"></iron-icon>
@@ -201,20 +202,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <div>
       <h4>Two-line items</h4>
-      <div class="list">
-        <paper-item>
+      <div class="list" role="list">
+        <paper-item tabindex="0">
           <paper-item-body two-line class="layout vertical">
             <div>Profile Photo</div>
             <div secondary>Change your Google+ profile photo</div>
           </paper-item-body>
         </paper-item>
-        <paper-item>
+        <paper-item tabindex="0">
           <paper-item-body two-line>
             <div>Show your status</div>
             <div secondary>Your status is visible to everyone you use with</div>
           </paper-item-body>
         </paper-item>
-        <paper-item>
+        <paper-item tabindex="0">
           <paper-item-body two-line class="layout vertical">
             <div>Settings</div>
             <div secondary>Change your account settings</div>
@@ -225,58 +226,58 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <div>
       <h4>Icon with two-line text</h4>
-      <div class="list">
-        <paper-icon-item>
+      <div class="list" role="list">
+        <paper-icon-item tabindex="0">
           <div class="avatar green" item-icon></div>
           <paper-item-body two-line>
             <div>Alphonso Engelking</div>
             <div secondary>Change photo</div>
           </paper-item-body>
         </paper-icon-item>
-        <paper-icon-item>
+        <paper-icon-item tabindex="0">
           <iron-icon icon="communication:phone" item-icon></iron-icon>
           <paper-item-body two-line>
             <div>(650) 555-1234</div>
             <div secondary>Mobile</div>
           </paper-item-body>
         </paper-icon-item>
-        <paper-icon-item>
+        <paper-icon-item tabindex="0">
           <iron-icon icon="communication:email" item-icon></iron-icon>
           <paper-item-body two-line>
             <div>alphonso@example.com</div>
             <div secondary>Personal</div>
           </paper-item-body>
         </paper-icon-item>
-        <paper-icon-item>
+        <paper-icon-item tabindex="0">
       </div>
     </div>
 
     <div>
       <h4>Avatar with text and icon</h4>
-      <div class="list">
-        <paper-icon-item>
+      <div class="list" role="list">
+        <paper-icon-item tabindex="0">
           <div class="avatar blue" item-icon></div>
           <paper-item-body two-line>
             <div>Photos</div>
             <div secondary>Jan 9, 2014</div>
           </paper-item-body>
-          <iron-icon icon="star"></iron-icon>
+          <paper-icon-button icon="star" alt="favourite this!"></paper-icon-button>
         </paper-icon-item>
-        <paper-icon-item>
+        <paper-icon-item tabindex="0">
           <div class="avatar red" item-icon></div>
           <paper-item-body two-line>
             <div>Recipes</div>
             <div secondary>Jan 17, 2014</div>
           </paper-item-body>
-          <iron-icon icon="star"></iron-icon>
+          <paper-icon-button icon="star" alt="favourite this!"></paper-icon-button>
         </paper-icon-item>
-        <paper-icon-item>
+        <paper-icon-item tabindex="0">
           <div class="avatar orange" item-icon></div>
           <paper-item-body two-line>
             <div>Work</div>
             <div secondary>Jan 28, 2014</div>
           </paper-item-body>
-          <iron-icon icon="star"></iron-icon>
+          <paper-icon-button icon="star" alt="favourite this!"></paper-icon-button>
         </paper-icon-item>
       </div>
     </div>

--- a/test/paper-item.html
+++ b/test/paper-item.html
@@ -31,13 +31,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <test-fixture id="item">
       <template>
-        <paper-item>item</paper-item>
+        <div role="list">
+          <paper-item>item</paper-item>
+        </div>
       </template>
     </test-fixture>
 
     <test-fixture id="iconItem">
       <template>
-        <paper-icon-item>item</paper-icon-item>
+        <div role="list">
+          <paper-icon-item>item</paper-icon-item>
+        </div>
       </template>
     </test-fixture>
 
@@ -47,8 +51,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var item, iconItem;
 
         setup(function() {
-          item = fixture('item');
-          iconItem = fixture('iconItem');
+          item = fixture('item').querySelector('paper-item');
+          iconItem = fixture('iconItem').querySelector('paper-icon-item');
         });
 
         test('item has role="listitem"', function() {
@@ -58,6 +62,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         test('icon item has role="listitem"', function() {
           assert.equal(iconItem.getAttribute('role'), 'listitem', 'has role="item"');
         });
+
+        a11ySuite('item');
+        a11ySuite('iconItem');
       });
 
     </script>


### PR DESCRIPTION
Fixes #23 
- most of the items aren't tabbable, which I think is weird. We can't add a tabindex to `paper-item` itself, since this will break something like `paper-menu`, so I added them directly to the demo
- made the `star` icons be buttons, so that they actually make sense (a star icon next to a content should probably be clickable)