### PR TITLE
clean up shared code and add tests

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -35,9 +35,10 @@
     "iron-icons": "PolymerElements/iron-icons#^1.0.0",
     "paper-checkbox": "PolymerElements/paper-checkbox#^1.0.0",
     "paper-icon-button": "PolymerElements/paper-icon-button#^1.0.0",
+    "paper-input": "PolymerElements/paper-input#^1.0.0",
     "paper-toggle-button": "PolymerElements/paper-toggle-button#^1.0.0",
     "test-fixture": "PolymerElements/test-fixture#^1.0.0",
-    "web-component-tester": "Polymer/web-component-tester#^3.3.0",
+    "web-component-tester": "Polymer/web-component-tester#^3.4.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0",
     "iron-test-helpers": "PolymerElements/iron-test-helpers#^1.0.0"
   }

--- a/bower.json
+++ b/bower.json
@@ -38,6 +38,7 @@
     "paper-toggle-button": "PolymerElements/paper-toggle-button#^1.0.0",
     "test-fixture": "PolymerElements/test-fixture#^1.0.0",
     "web-component-tester": "Polymer/web-component-tester#^3.3.0",
-    "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
+    "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0",
+    "iron-test-helpers": "PolymerElements/iron-test-helpers#^1.0.0"
   }
 }

--- a/demo/index.html
+++ b/demo/index.html
@@ -31,6 +31,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <link rel="import" href="../../iron-flex-layout/iron-flex-layout.html">
   <link rel="import" href="../../paper-styles/demo-pages.html">
 
+  <link rel="import" href="../../paper-input/paper-input.html">
+
   <style is="custom-style">
     .list {
       padding-top: 12px;
@@ -88,7 +90,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <div>
       <h4>Single line items</h4>
       <div class="list short" role="listbox">
-        <paper-item>Inbox</paper-item>
+        <paper-item><paper-input></paper-input></paper-item>
         <paper-item>Starred</paper-item>
         <paper-item>Sent mail</paper-item>
         <paper-item>Drafts</paper-item>

--- a/paper-icon-item.html
+++ b/paper-icon-item.html
@@ -13,11 +13,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../iron-behaviors/iron-button-state.html">
 <link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
 <link rel="import" href="../paper-styles/typography.html">
-
+<link rel="import" href="paper-item-behavior.html">
 <link rel="import" href="paper-item-shared-styles.html">
 
 <!--
-`<paper-icon-item>` is a convenience element to make an item with icon. It is a non interactive list
+`<paper-icon-item>` is a convenience element to make an item with icon. It is an interactive list
 item with a fixed-width icon area, according to Material Design. This is useful if the icons are of
 varying widths, but you want the item bodies to line up. Use this like a `<paper-item>`. The child
 node with the attribute `item-icon` is placed in the icon area.
@@ -45,7 +45,6 @@ Custom property               | Description                                    |
 `--paper-item-disabled`       | Mixin applied to disabled paper-items        | `{}`
 `--paper-item-focused`        | Mixin applied to focused paper-items         | `{}`
 `--paper-item-focused-before` | Mixin applied to :before focused paper-items | `{}`
-
 -->
 
 <dom-module id="paper-icon-item">
@@ -78,14 +77,8 @@ Custom property               | Description                                    |
     Polymer({
       is: 'paper-icon-item',
 
-      hostAttributes: {
-        'role': 'option',
-        'tabindex': '0'
-      },
-
       behaviors: [
-        Polymer.IronControlState,
-        Polymer.IronButtonState
+        Polymer.PaperItemBehavior
       ]
     });
   </script>

--- a/paper-item-behavior.html
+++ b/paper-item-behavior.html
@@ -19,43 +19,19 @@ the items.
 -->
 
 <script>
+  /** @polymerBehavior Polymer.PaperItemBehavior */
+  Polymer.PaperItemBehaviorImpl = {
+    hostAttributes: {
+      role: 'option',
+      tabindex: '0'
+    }
+  };
+
   /** @polymerBehavior */
   Polymer.PaperItemBehavior = [
     Polymer.IronControlState,
     Polymer.IronButtonState,
-    {
-      hostAttributes: {
-        role: 'listitem',
-        tabindex: '0'
-      },
-
-      /**
-       * A handler that is called when the space is pressed. Overriden
-       * from IronButtonState.
-       *
-       * @param {CustomEvent} event A custom keyboard event.
-       */
-      _spaceKeyDownHandler: function(event) {
-        // Only handle the event if it's not coming from a child element.
-        var keyboardEvent = event.detail.keyboardEvent;
-        if (Polymer.Gestures.findOriginalTarget(keyboardEvent) === this) {
-          Polymer.IronButtonStateImpl._spaceKeyDownHandler.apply(this, [event]);
-        }
-      },
-
-      /**
-       * A handler that is called when the space is released. Overriden
-       * from IronButtonState.
-       *
-       * @param {CustomEvent} event A custom keyboard event.
-       */
-      _spaceKeyUpHandler: function(event) {
-        // Only handle the event if it's not coming from a child element.
-        var keyboardEvent = event.detail.keyboardEvent;
-        if (Polymer.Gestures.findOriginalTarget(keyboardEvent) === this) {
-          Polymer.IronButtonStateImpl._spaceKeyUpHandler.apply(this);
-        }
-      }
-    }
+    Polymer.PaperItemBehaviorImpl
   ];
+
 </script>

--- a/paper-item-behavior.html
+++ b/paper-item-behavior.html
@@ -1,0 +1,61 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../iron-behaviors/iron-control-state.html">
+<link rel="import" href="../iron-behaviors/iron-button-state.html">
+
+<!--
+`PaperItemBehavior` is a convenience behavior shared by <paper-item> and
+<paper-icon-item> that manages the shared control states and attributes of
+the items.
+-->
+
+<script>
+  /** @polymerBehavior */
+  Polymer.PaperItemBehavior = [
+    Polymer.IronControlState,
+    Polymer.IronButtonState,
+    {
+      hostAttributes: {
+        role: 'listitem',
+        tabindex: '0'
+      },
+
+      /**
+       * A handler that is called when the space is pressed. Overriden
+       * from IronButtonState.
+       *
+       * @param {CustomEvent} event A custom keyboard event.
+       */
+      _spaceKeyDownHandler: function(event) {
+        // Only handle the event if it's not coming from a child element.
+        var keyboardEvent = event.detail.keyboardEvent;
+        if (Polymer.Gestures.findOriginalTarget(keyboardEvent) === this) {
+          Polymer.IronButtonStateImpl._spaceKeyDownHandler.apply(this, [event]);
+        }
+      },
+
+      /**
+       * A handler that is called when the space is released. Overriden
+       * from IronButtonState.
+       *
+       * @param {CustomEvent} event A custom keyboard event.
+       */
+      _spaceKeyUpHandler: function(event) {
+        // Only handle the event if it's not coming from a child element.
+        var keyboardEvent = event.detail.keyboardEvent;
+        if (Polymer.Gestures.findOriginalTarget(keyboardEvent) === this) {
+          Polymer.IronButtonStateImpl._spaceKeyUpHandler.apply(this);
+        }
+      }
+    }
+  ];
+</script>

--- a/paper-item.html
+++ b/paper-item.html
@@ -13,12 +13,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../iron-behaviors/iron-button-state.html">
 <link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
 <link rel="import" href="../paper-styles/default-theme.html">
+<link rel="import" href="paper-item-behavior.html">
 <link rel="import" href="paper-item-shared-styles.html">
 
 <!--
 Material design: [Lists](https://www.google.com/design/spec/components/lists.html)
 
-`<paper-item>` is a non-interactive list item. By default, it is a horizontal flexbox.
+`<paper-item>` is an interactive list item. By default, it is a horizontal flexbox.
 
     <paper-item>Item</paper-item>
 
@@ -47,7 +48,6 @@ Custom property               | Description                                    |
 `--paper-item-disabled`       | Mixin applied to disabled paper-items        | `{}`
 `--paper-item-focused`        | Mixin applied to focused paper-items         | `{}`
 `--paper-item-focused-before` | Mixin applied to :before focused paper-items | `{}`
-
 
 ### Accessibility
 
@@ -86,14 +86,8 @@ This element has `role="listitem"` by default. Depending on usage, it may be mor
     Polymer({
       is: 'paper-item',
 
-      hostAttributes: {
-        role: 'option',
-        tabindex: '0'
-      },
-
       behaviors: [
-        Polymer.IronControlState,
-        Polymer.IronButtonState
+        Polymer.PaperItemBehavior
       ]
     });
   </script>

--- a/test/paper-item.html
+++ b/test/paper-item.html
@@ -20,10 +20,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 
     <script src="../../web-component-tester/browser.js"></script>
-    <script src="../../test-fixture/test-fixture-mocha.js"></script>
     <script src="../../iron-test-helpers/mock-interactions.js"></script>
 
-    <link rel="import" href="../../test-fixture/test-fixture.html">
+    <link rel="import" href="../../paper-input/paper-input.html">
     <link rel="import" href="../paper-item.html">
     <link rel="import" href="../paper-icon-item.html">
 
@@ -54,6 +53,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </template>
     </test-fixture>
 
+    <test-fixture id="item-with-paper-input">
+      <template>
+        <div role="list">
+          <paper-item><paper-input></paper-input></paper-item>
+        </div>
+      </template>
+    </test-fixture>
+
     <test-fixture id="iconItem-with-input">
       <template>
         <div role="list">
@@ -72,18 +79,24 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           item.addEventListener('click', clickHandler);
         });
 
-        test('space triggers a click event', function() {
+        test('space triggers a click event', function(done) {
           MockInteractions.pressSpace(item);
-          setTimeout(function(){
-            expect(clickHandler.callCount).to.be.equal(1);
-          }, 100);
+          Polymer.Base.async(function(){
+            // You need two ticks, one for the MockInteractions event, and one
+            // for the button event.
+            Polymer.Base.async(function(){
+              expect(clickHandler.callCount).to.be.equal(1);
+              done();
+            }, 1);
+          }, 1);
         });
 
-        test('click triggers a click event', function() {
+        test('click triggers a click event', function(done) {
           MockInteractions.tap(item);
-          setTimeout(function(){
+          Polymer.Base.async(function(){
             expect(clickHandler.callCount).to.be.equal(1);
-          }, 100);
+            done();
+          }, 1);
         });
       });
 
@@ -96,46 +109,73 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           item.addEventListener('click', clickHandler);
         });
 
-        test('space triggers a click event', function() {
+        test('space triggers a click event', function(done) {
           MockInteractions.pressSpace(item);
-          setTimeout(function(){
-            expect(clickHandler.callCount).to.be.equal(1);
-          }, 100);
+          Polymer.Base.async(function(){
+            // You need two ticks, one for the MockInteractions event, and one
+            // for the button event.
+            Polymer.Base.async(function(){
+              expect(clickHandler.callCount).to.be.equal(1);
+              done();
+            }, 1);
+          }, 1);
         });
 
-        test('click triggers a click event', function() {
+        test('click triggers a click event', function(done) {
           MockInteractions.tap(item);
-          setTimeout(function(){
+          Polymer.Base.async(function(){
             expect(clickHandler.callCount).to.be.equal(1);
-          }, 100);
+            done();
+          }, 1);
         });
       });
 
       suite('clickable element inside item', function() {
-        test('paper-item: space in child input does not trigger a click event', function() {
-          var outerItem = fixture('item-with-input').querySelector('paper-item');
-          var innerInput = fixture('item-with-input').querySelector('input');
+        test('paper-item: space in child native input does not trigger a click event', function(done) {
+          var f = fixture('item-with-input');
+          var outerItem = f.querySelector('paper-item');
+          var innerInput = f.querySelector('input');
 
           var itemClickHandler = sinon.spy();
           outerItem.addEventListener('click', itemClickHandler);
 
+          innerInput.focus();
           MockInteractions.pressSpace(innerInput);
-          setTimeout(function(){
+          Polymer.Base.async(function(){
             expect(itemClickHandler.callCount).to.be.equal(0);
-          }, 100);
+            done();
+          }, 1);
         });
 
-        test('paper-icon-item: space in child input does not trigger a click event', function() {
-          var outerItem = fixture('iconItem-with-input').querySelector('paper-icon-item');
-          var innerInput = fixture('iconItem-with-input').querySelector('input');
+        test('paper-item: space in child paper-input does not trigger a click event', function(done) {
+          var f = fixture('item-with-paper-input');
+          var outerItem = f.querySelector('paper-item');
+          var innerInput = f.querySelector('paper-input');
+
+          var itemClickHandler = sinon.spy();
+          outerItem.addEventListener('click', itemClickHandler);
+
+          innerInput.focus();
+          MockInteractions.pressSpace(innerInput);
+          Polymer.Base.async(function(){
+            expect(itemClickHandler.callCount).to.be.equal(0);
+            done();
+          }, 1);
+        });
+
+        test('paper-icon-item: space in child input does not trigger a click event', function(done) {
+          var f = fixture('iconItem-with-input');
+          var outerItem = f.querySelector('paper-icon-item');
+          var innerInput = f.querySelector('input');
 
           var itemClickHandler = sinon.spy();
           outerItem.addEventListener('click', itemClickHandler);
 
           MockInteractions.pressSpace(innerInput);
-          setTimeout(function(){
+          Polymer.Base.async(function(){
             expect(itemClickHandler.callCount).to.be.equal(0);
-          }, 100);
+            done();
+          }, 1);
         });
       });
 

--- a/test/paper-item.html
+++ b/test/paper-item.html
@@ -21,6 +21,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <script src="../../web-component-tester/browser.js"></script>
     <script src="../../test-fixture/test-fixture-mocha.js"></script>
+    <script src="../../iron-test-helpers/mock-interactions.js"></script>
 
     <link rel="import" href="../../test-fixture/test-fixture.html">
     <link rel="import" href="../paper-item.html">
@@ -45,7 +46,98 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </template>
     </test-fixture>
 
+    <test-fixture id="item-with-input">
+      <template>
+        <div role="list">
+          <paper-item><input></paper-item>
+        </div>
+      </template>
+    </test-fixture>
+
+    <test-fixture id="iconItem-with-input">
+      <template>
+        <div role="list">
+          <paper-icon-item><input></paper-icon-item>
+        </div>
+      </template>
+    </test-fixture>
+
     <script>
+      suite('paper-item basic', function() {
+        var item, clickHandler;
+
+        setup(function() {
+          item = fixture('item').querySelector('paper-item');
+          clickHandler = sinon.spy();
+          item.addEventListener('click', clickHandler);
+        });
+
+        test('space triggers a click event', function() {
+          MockInteractions.pressSpace(item);
+          setTimeout(function(){
+            expect(clickHandler.callCount).to.be.equal(1);
+          }, 100);
+        });
+
+        test('click triggers a click event', function() {
+          MockInteractions.tap(item);
+          setTimeout(function(){
+            expect(clickHandler.callCount).to.be.equal(1);
+          }, 100);
+        });
+      });
+
+      suite('paper-icon-item basic', function() {
+        var item, clickHandler;
+
+        setup(function() {
+          item = fixture('iconItem').querySelector('paper-icon-item');
+          clickHandler = sinon.spy();
+          item.addEventListener('click', clickHandler);
+        });
+
+        test('space triggers a click event', function() {
+          MockInteractions.pressSpace(item);
+          setTimeout(function(){
+            expect(clickHandler.callCount).to.be.equal(1);
+          }, 100);
+        });
+
+        test('click triggers a click event', function() {
+          MockInteractions.tap(item);
+          setTimeout(function(){
+            expect(clickHandler.callCount).to.be.equal(1);
+          }, 100);
+        });
+      });
+
+      suite('clickable element inside item', function() {
+        test('paper-item: space in child input does not trigger a click event', function() {
+          var outerItem = fixture('item-with-input').querySelector('paper-item');
+          var innerInput = fixture('item-with-input').querySelector('input');
+
+          var itemClickHandler = sinon.spy();
+          outerItem.addEventListener('click', itemClickHandler);
+
+          MockInteractions.pressSpace(innerInput);
+          setTimeout(function(){
+            expect(itemClickHandler.callCount).to.be.equal(0);
+          }, 100);
+        });
+
+        test('paper-icon-item: space in child input does not trigger a click event', function() {
+          var outerItem = fixture('iconItem-with-input').querySelector('paper-icon-item');
+          var innerInput = fixture('iconItem-with-input').querySelector('input');
+
+          var itemClickHandler = sinon.spy();
+          outerItem.addEventListener('click', itemClickHandler);
+
+          MockInteractions.pressSpace(innerInput);
+          setTimeout(function(){
+            expect(itemClickHandler.callCount).to.be.equal(0);
+          }, 100);
+        });
+      });
 
       suite('item a11y tests', function() {
         var item, iconItem;


### PR DESCRIPTION
Pulls out all the common code into a shared behaviour because copy :spaghetti: is bad news :bear::bear:

And adds :tada: tests :tada: !!!

(fixes the comment in https://github.com/PolymerElements/paper-item/issues/38)