### PR TITLE
Paper-item defines own focus and disabled styles

### DIFF
--- a/paper-icon-item.html
+++ b/paper-icon-item.html
@@ -33,10 +33,16 @@ node with the attribute `item-icon` is placed in the icon area.
 
 The following custom properties and mixins are available for styling:
 
-Custom property | Description | Default
-----------------|-------------|----------
-`--paper-item-icon-width` | Width of the icon area     | `56px`
-`--paper-icon-item`       | Mixin applied to the item  | `{}`
+Custom property               | Description                                    | Default
+------------------------------|------------------------------------------------|----------
+`--paper-item-icon-width`     | Width of the icon area                         | `56px`
+`--paper-icon-item`           | Mixin applied to the item                      | `{}`
+`--paper-item-selected-weight`| The font weight of a selected item             | `bold`
+`--paper-item-selected`       | Mixin applied to selected paper-items                | `{}`
+`--paper-item-disabled-color` | The color for disabled paper-items             | `--disabled-text-color`
+`--paper-item-disabled`       | Mixin applied to disabled paper-items        | `{}`
+`--paper-item-focused`        | Mixin applied to focused paper-items         | `{}`
+`--paper-item-focused-before` | Mixin applied to :before focused paper-items | `{}`
 
 -->
 

--- a/paper-item-shared-styles.html
+++ b/paper-item-shared-styles.html
@@ -17,8 +17,29 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         padding: 0px 16px;
       }
 
-      :host > ::content > *:not(:first-child):not(:last-child) {
-        margin-right: 16px;
+      :host(.iron-selected) {
+        font-weight: var(--paper-item-selected-weight, bold);
+        @apply(--paper-item-selected);
+      }
+
+      :host([disabled]) {
+        color: var(--paper-item-disabled-color, --disabled-text-color);
+        @apply(--paper-item-disabled);
+      }
+
+      :host(:focus) {
+        position: relative;
+        outline: 0;
+        @apply(--paper-item-focused);
+      }
+
+      :host(:focus:before) {
+        @apply(--layout-fit);
+        content: '';
+        background: currentColor;
+        opacity: var(--dark-divider-opacity);
+
+        @apply(--paper-item-focused-before);
       }
     </style>
   </template>

--- a/paper-item.html
+++ b/paper-item.html
@@ -36,10 +36,17 @@ items.
 
 The following custom properties and mixins are available for styling:
 
-Custom property | Description | Default
-----------------|-------------|----------
-`--paper-item-min-height` | Minimum height of the item | `48px`
-`--paper-item`            | Mixin applied to the item  | `{}`
+Custom property               | Description                                    | Default
+------------------------------|------------------------------------------------|----------
+`--paper-item-min-height`     | Minimum height of the item                     | `48px`
+`--paper-item`                | Mixin applied to the item                      | `{}`
+`--paper-item-selected-weight`| The font weight of a selected item             | `bold`
+`--paper-item-selected`       | Mixin applied to selected paper-items                | `{}`
+`--paper-item-disabled-color` | The color for disabled paper-items             | `--disabled-text-color`
+`--paper-item-disabled`       | Mixin applied to disabled paper-items        | `{}`
+`--paper-item-focused`        | Mixin applied to focused paper-items         | `{}`
+`--paper-item-focused-before` | Mixin applied to :before focused paper-items | `{}`
+
 
 ### Accessibility
 


### PR DESCRIPTION
This can probably be merged on its own as Not a Breaking Change™. However, it ties in directly to a forthcoming PR for `paper-menu` that almost certainly represents a breaking change.