### PR TITLE
`:before` should not style host context.

### DIFF
--- a/paper-item-shared-styles.html
+++ b/paper-item-shared-styles.html
@@ -33,7 +33,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         @apply(--paper-item-focused);
       }
 
-      :host(:focus:before) {
+      :host(:focus):before {
         @apply(--layout-fit);
         content: '';
         background: currentColor;


### PR DESCRIPTION
This was causing ridiculous visual artifacts when items are viewed in ShadowDOM.