### PR TITLE
fix imports broken by the paper-styles cleanup

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -30,9 +30,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <link rel="import" href="../paper-item-body.html">
   <link rel="import" href="../../iron-flex-layout/iron-flex-layout.html">
   <link rel="import" href="../../paper-styles/demo-pages.html">
-
-  <link rel="import" href="../../paper-input/paper-input.html">
-
+  
   <style is="custom-style">
     .list {
       padding-top: 12px;
@@ -90,7 +88,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <div>
       <h4>Single line items</h4>
       <div class="list short" role="listbox">
-        <paper-item><paper-input></paper-input></paper-item>
+        <paper-item>Inbox</paper-item>
         <paper-item>Starred</paper-item>
         <paper-item>Sent mail</paper-item>
         <paper-item>Drafts</paper-item>

--- a/paper-icon-item.html
+++ b/paper-icon-item.html
@@ -13,6 +13,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../iron-behaviors/iron-button-state.html">
 <link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
 <link rel="import" href="../paper-styles/typography.html">
+<link rel="import" href="../paper-styles/color.html">
+<link rel="import" href="../paper-styles/default-theme.html">
 <link rel="import" href="paper-item-behavior.html">
 <link rel="import" href="paper-item-shared-styles.html">
 

--- a/paper-item-body.html
+++ b/paper-item-body.html
@@ -11,6 +11,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
 <link rel="import" href="../paper-styles/default-theme.html">
+<link rel="import" href="../paper-styles/color.html">
 <link rel="import" href="../paper-styles/typography.html">
 <!--
 Use `<paper-item-body>` in a `<paper-item>` or `<paper-icon-item>` to make two- or

--- a/paper-item.html
+++ b/paper-item.html
@@ -13,6 +13,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../iron-behaviors/iron-button-state.html">
 <link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
 <link rel="import" href="../paper-styles/default-theme.html">
+<link rel="import" href="../paper-styles/color.html">
 <link rel="import" href="paper-item-behavior.html">
 <link rel="import" href="paper-item-shared-styles.html">
 


### PR DESCRIPTION
Fixes #55  (missing imports that are used in the shared styles)

Also, I think I accidentally messed up the demo when fixing the input-inside-an-item case, so I undid that bit.