### PR TITLE
fix host: styles

### DIFF
--- a/paper-item-shared-styles.html
+++ b/paper-item-shared-styles.html
@@ -13,8 +13,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <style>
       :host {
         display: block;
+        position: relative;
         min-height: var(--paper-item-min-height, 48px);
         padding: 0px 16px;
+      }
+
+      :host([hidden]) {
+        display: none !important;
       }
 
       :host(.iron-selected) {


### PR DESCRIPTION
- fixes https://github.com/PolymerElements/paper-item/issues/58 by adding `:host([hidden])` style
- fixes https://github.com/PolymerElements/paper-item/issues/54 (and https://github.com/PolymerElements/paper-badge/issues/27) by adding a `position: relative` to the host, which was already being applied on `focus`.