### PR TITLE
Apply --layout-vertical to the parent instead of `height: 1px` hack

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -32,9 +32,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <link rel="import" href="../../paper-styles/demo-pages.html">
   <style is="custom-style">
     .list {
+      @apply(--layout-vertical);
+
       padding-top: 12px;
       background-color: white;
-      display: inline-block;
       width: 240px;
       height: 228px;
       margin: 12px;

--- a/paper-item-shared-styles.html
+++ b/paper-item-shared-styles.html
@@ -20,14 +20,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         position: relative;
         min-height: var(--paper-item-min-height, 48px);
         padding: 0px 16px;
-
-        /**
-         * This seemingly unnecessary height attribute is needed for an IE 11
-         * bug where flexbox elements are not vertically aligned if the height
-         * property is not specified, even when min-height is present. See
-         * https://github.com/PolymerElements/paper-item/issues/35.
-         */
-        height: 1px;
       }
 
       :host([hidden]) {


### PR DESCRIPTION
The `height: 1px;` hack in PR #57 for `<paper-item>` (intended to fix #35) doesn't work when there is a two-/three-line `<paper-item-body>` nested within it, since `<paper-item>` would take on its `min-height` of 48px and `<paper-item-body>` would be something longer.

Instead, another potential fix is to apply `display: flex; flex-direction: column;` to `<paper-item>`'s parent instead, as demonstrated in this updated demo page. Tested on IE11.