### PR TITLE
Allow mixing in of the actual icon

### DIFF
--- a/paper-icon-item.html
+++ b/paper-icon-item.html
@@ -36,6 +36,7 @@ The following custom properties and mixins are available for styling:
 Custom property               | Description                                    | Default
 ------------------------------|------------------------------------------------|----------
 `--paper-item-icon-width`     | Width of the icon area                         | `56px`
+`--paper-item-icon`           | Mixin applied to the icon area                 | `{}`
 `--paper-icon-item`           | Mixin applied to the item                      | `{}`
 `--paper-item-selected-weight`| The font weight of a selected item             | `bold`
 `--paper-item-selected`       | Mixin applied to selected paper-items                | `{}`
@@ -63,6 +64,7 @@ Custom property               | Description                                    |
         @apply(--layout-center);
 
         width: var(--paper-item-icon-width, 56px);
+        @apply(--paper-item-icon);
       }
     </style>
 


### PR DESCRIPTION
In the current scenario it's impossible to for example set `align-self: flex-start` to the icon, to vertically align it, this solves that.