### PR TITLE
Add box-sizing: border-box; to paper-item

### DIFF
--- a/paper-item-shared-styles.html
+++ b/paper-item-shared-styles.html
@@ -20,6 +20,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         position: relative;
         min-height: var(--paper-item-min-height, 48px);
         padding: 0px 16px;
+        box-sizing: border-box;
       }
 
       :host([hidden]) {


### PR DESCRIPTION
Because the paper-item has padding, we have problems with sizing.
I propose add `box-sizing: border-box`.

With the same code:

* Before `box-sizing: border-box`: https://jsbin.com/sururamiha/edit?html,output

![screen shot 2016-02-09 at 16 28 53](https://cloud.githubusercontent.com/assets/1007051/12920778/51514fc6-cf4a-11e5-8551-c1471cbed781.png)

* After `box-sizing: border-box`: https://jsbin.com/qigiyerojo/edit?html,output

![screen shot 2016-02-09 at 16 29 22](https://cloud.githubusercontent.com/assets/1007051/12920780/5524beee-cf4a-11e5-8a73-bbcca776e640.png)