### PR TITLE
Fixes #21: Adds an example of using paper-items as links.

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -163,6 +163,29 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         </div>
       </template>
     </demo-snippet>
+
+    <h3>Paper-items can be used as links</h3>
+    <demo-snippet>
+      <template>
+        <style is="custom-style">
+          .paper-item-link {
+            color: inherit;
+            text-decoration: none;
+          }
+        </style>
+        <div role="listbox">
+          <a class="paper-item-link" href="#inbox" tabindex="-1">
+            <paper-item>Inbox</paper-item>
+          </a>
+          <a class="paper-item-link" href="#starred" tabindex="-1">
+            <paper-item>Starred</paper-item>
+          </a>
+          <a class="paper-item-link" href="#sent" tabindex="-1">
+            <paper-item>Sent mail</paper-item>
+          </a>
+        </div>
+      </template>
+    </demo-snippet>
   </div>
 </body>
 </html>

--- a/paper-item.html
+++ b/paper-item.html
@@ -31,6 +31,14 @@ items.
       <iron-icon icon="warning"></iron-icon>
     </paper-item>
 
+To use `paper-item` as a link, wrap it in an anchor tag. Since `paper-item` will
+already receive focus, you may want to prevent the anchor tag from receiving
+focus as well by setting its tabindex to -1.
+
+    <a href="https://www.polymer-project.org/" tabindex="-1">
+      <paper-item raised>Polymer Project</paper-item>
+    </a>
+
 ### Styling
 
 The following custom properties and mixins are available for styling:


### PR DESCRIPTION
Following @keanulee's example in ~~#91~~PolymerElements/paper-button#91 - literally.