### PR TITLE
Fix #44

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,6 @@
   ],
   "main": [
     "paper-item.html",
-    "paper-icon-item.html",
     "paper-item-body.html"
   ],
   "private": true,

--- a/demo/index.html
+++ b/demo/index.html
@@ -25,7 +25,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <link rel="import" href="../../iron-demo-helpers/demo-snippet.html">
   <link rel="import" href="../../iron-demo-helpers/demo-pages-shared-styles.html">
   <link rel="import" href="../../paper-icon-button/paper-icon-button.html">
-  <link rel="import" href="../paper-icon-item.html">
   <link rel="import" href="../paper-item.html">
   <link rel="import" href="../paper-item-body.html">
   <link rel="import" href="../../paper-styles/color.html">
@@ -84,32 +83,32 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </template>
     </demo-snippet>
 
-    <h3>To add a leading element, use a paper-icon-item with an <i>item-icon</i> attribute. This
+    <h3>To add a leading element, use a paper-item with an <i>item-icon</i> attribute. This
     leading image can be an iron-icon, or any other regular element.</h3>
     <demo-snippet>
       <template>
         <div role="listbox">
-          <paper-icon-item>
+          <paper-item>
             <iron-icon icon="inbox" item-icon></iron-icon>
             Inbox
-          </paper-icon-item>
-          <paper-icon-item>
+          </paper-item>
+          <paper-item>
             <iron-icon icon="star" item-icon></iron-icon>
             Starred
-          </paper-icon-item>
-          <paper-icon-item>
+          </paper-item>
+          <paper-item>
             <div class="avatar blue" item-icon></div>
             Alphonso Engelking
-          </paper-icon-item>
-          <paper-icon-item>
+          </paper-item>
+          <paper-item>
             <div class="avatar" item-icon></div>
             Angela Decker
-          </paper-icon-item>
+          </paper-item>
         </div>
       </template>
     </demo-snippet>
 
-    <h3>For two-line items, use a paper-item-body inside a paper-item or paper-icon-item</h3>
+    <h3>For two-line items, use a paper-item-body inside a paper-item</h3>
     <demo-snippet>
       <template>
         <div role="listbox">
@@ -119,21 +118,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               <div secondary>Change your Google+ profile photo</div>
             </paper-item-body>
           </paper-item>
-          <paper-icon-item>
+          <paper-item>
             <iron-icon icon="communication:phone" item-icon>
             </iron-icon>
             <paper-item-body two-line>
               <div>(650) 555-1234</div>
               <div secondary>Mobile</div>
             </paper-item-body>
-          </paper-icon-item>
-          <paper-icon-item>
+          </paper-item>
+          <paper-item>
             <div class="avatar blue" item-icon></div>
             <paper-item-body two-line>
               <div>Alphonso Engelking</div>
               <div secondary>Change photo</div>
             </paper-item-body>
-          </paper-icon-item>
+          </paper-item>
         </div>
       </template>
     </demo-snippet>
@@ -142,7 +141,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <demo-snippet>
       <template>
         <div role="listbox">
-          <paper-icon-item>
+          <paper-item>
             <div class="avatar blue" item-icon></div>
             <paper-item-body two-line>
               <div>Photos</div>
@@ -150,8 +149,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             </paper-item-body>
             <paper-icon-button icon="star" alt="favourite this!">
             </paper-icon-button>
-          </paper-icon-item>
-          <paper-icon-item>
+          </paper-item>
+          <paper-item>
             <div class="avatar" item-icon></div>
             <paper-item-body two-line>
               <div>Recipes</div>
@@ -159,7 +158,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             </paper-item-body>
             <paper-icon-button icon="star" alt="favourite this!">
             </paper-icon-button>
-          </paper-icon-item>
+          </paper-item>
         </div>
       </template>
     </demo-snippet>

--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 </head>
 <body>
 
-  <iron-component-page src="all-imports.html"></iron-component-page>
+  <iron-component-page sources='["paper-item.html", "paper-item-body.html"]'></iron-component-page>
 
 </body>
 </html>

--- a/paper-item.html
+++ b/paper-item.html
@@ -9,9 +9,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../iron-behaviors/iron-button-state.html">
+<link rel="import" href="../iron-behaviors/iron-control-state.html">
 <link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
 <link rel="import" href="paper-item-behavior.html">
-<link rel="import" href="paper-item-shared-styles.html">
 
 <!--
 Material design: [Lists](https://www.google.com/design/spec/components/lists.html)
@@ -29,6 +30,20 @@ items.
         <div secondary>Your status is visible to everyone</div>
       </paper-item-body>
       <iron-icon icon="warning"></iron-icon>
+    </paper-item>
+
+Use the `item-icon` property to make an item with icon. It is an interactive
+list item with a fixed-width icon area, according to Material Design. This is
+useful if the icons are of varying widths, but you want the item bodies to line
+up. The child node with the attribute `item-icon` is placed in the icon area.
+
+    <paper-item>
+      <iron-icon icon="favorite" item-icon></iron-icon>
+      Favorite
+    </paper-item>
+    <paper-item>
+      <div class="avatar" item-icon></div>
+      Avatar
     </paper-item>
 
 To use `paper-item` as a link, wrap it in an anchor tag. Since `paper-item` will
@@ -85,17 +100,68 @@ This element has `role="listitem"` by default. Depending on usage, it may be mor
 
 <dom-module id="paper-item">
   <template>
-    <style include="paper-item-shared-styles"></style>
     <style>
       :host {
         @apply(--layout-horizontal);
         @apply(--layout-center);
         @apply(--paper-font-subhead);
 
+        position: relative;
+
+        min-height: var(--paper-item-min-height, 48px);
+        padding: 0px 16px;
+
         @apply(--paper-item);
+      }
+
+      :host([hidden]) {
+        display: none !important;
+      }
+
+      :host(.iron-selected) {
+        font-weight: var(--paper-item-selected-weight, bold);
+
+        @apply(--paper-item-selected);
+      }
+
+      :host([disabled]) {
+        color: var(--paper-item-disabled-color, --disabled-text-color);
+
+        @apply(--paper-item-disabled);
+      }
+
+      :host(:focus) {
+        position: relative;
+        outline: 0;
+
+        @apply(--paper-item-focused);
+      }
+
+      :host(:focus):before {
+        @apply(--layout-fit);
+
+        content: '';
+        pointer-events: none;
+
+        opacity: var(--dark-divider-opacity);
+        background: currentColor;
+
+        @apply(--paper-item-focused-before);
+      }
+
+      .content-icon {
+        @apply(--layout-horizontal);
+        @apply(--layout-center);
+
+        width: var(--paper-item-icon-width, 56px);
+
+        @apply(--paper-item-icon);
       }
     </style>
 
+    <div id="contentIcon" class="content-icon" hidden>
+      <content select="[item-icon]"></content>
+    </div>
     <content></content>
   </template>
 
@@ -103,9 +169,21 @@ This element has `role="listitem"` by default. Depending on usage, it may be mor
     Polymer({
       is: 'paper-item',
 
+      hostAttributes: {
+        role: 'option',
+        tabindex: '0'
+      },
+
       behaviors: [
-        Polymer.PaperItemBehavior
-      ]
+        Polymer.IronButtonState,
+        Polymer.IronControlState
+      ],
+
+      ready: function() {
+        if (this.queryEffectiveChildren('[item-icon]')) {
+          this.$.contentIcon.removeAttribute('hidden');
+        }
+      }
     });
   </script>
 </dom-module>

--- a/test/paper-item.html
+++ b/test/paper-item.html
@@ -24,7 +24,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <link rel="import" href="../../paper-input/paper-input.html">
     <link rel="import" href="../paper-item.html">
-    <link rel="import" href="../paper-icon-item.html">
 
   </head>
   <body>
@@ -45,14 +44,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </template>
     </test-fixture>
 
-    <test-fixture id="iconItem">
-      <template>
-        <div role="listbox">
-          <paper-icon-item>item</paper-icon-item>
-        </div>
-      </template>
-    </test-fixture>
-
     <test-fixture id="item-with-input">
       <template>
         <div role="list">
@@ -65,14 +56,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <template>
         <div role="list">
           <paper-item><paper-input></paper-input></paper-item>
-        </div>
-      </template>
-    </test-fixture>
-
-    <test-fixture id="iconItem-with-input">
-      <template>
-        <div role="list">
-          <paper-icon-item><input></paper-icon-item>
         </div>
       </template>
     </test-fixture>
@@ -112,36 +95,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
       });
 
-      suite('paper-icon-item basic', function() {
-        var item, clickHandler;
-
-        setup(function() {
-          item = fixture('iconItem').querySelector('paper-icon-item');
-          clickHandler = sinon.spy();
-          item.addEventListener('click', clickHandler);
-        });
-
-        test('space triggers a click event', function(done) {
-          MockInteractions.pressSpace(item);
-          Polymer.Base.async(function(){
-            // You need two ticks, one for the MockInteractions event, and one
-            // for the button event.
-            Polymer.Base.async(function(){
-              expect(clickHandler.callCount).to.be.equal(1);
-              done();
-            }, 1);
-          }, 1);
-        });
-
-        test('click triggers a click event', function(done) {
-          MockInteractions.tap(item);
-          Polymer.Base.async(function(){
-            expect(clickHandler.callCount).to.be.equal(1);
-            done();
-          }, 1);
-        });
-      });
-
       suite('clickable element inside item', function() {
         test('paper-item: space in child native input does not trigger a click event', function(done) {
           var f = fixture('item-with-input');
@@ -174,44 +127,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             done();
           }, 1);
         });
-
-        test('paper-icon-item: space in child input does not trigger a click event', function(done) {
-          var f = fixture('iconItem-with-input');
-          var outerItem = f.querySelector('paper-icon-item');
-          var innerInput = f.querySelector('input');
-
-          var itemClickHandler = sinon.spy();
-          outerItem.addEventListener('click', itemClickHandler);
-
-          MockInteractions.pressSpace(innerInput);
-          Polymer.Base.async(function(){
-            expect(itemClickHandler.callCount).to.be.equal(0);
-            done();
-          }, 1);
-        });
       });
 
       suite('item a11y tests', function() {
-        var item, iconItem;
+        var item;
 
         setup(function() {
           item = fixture('item').querySelector('paper-item');
-          iconItem = fixture('iconItem').querySelector('paper-icon-item');
         });
 
         test('item has role="listitem"', function() {
           assert.equal(item.getAttribute('role'), 'option', 'has role="option"');
         });
 
-        test('icon item has role="listitem"', function() {
-          assert.equal(iconItem.getAttribute('role'), 'option', 'has role="option"');
-        });
-
         a11ySuite('item');
         a11ySuite('button');
-        a11ySuite('iconItem');
       });
-
     </script>
 
   </body>


### PR DESCRIPTION
Now paper-input can have icons itself without breaking changes

With this changes, we can deprecate (not remove for breaking changes) a lot of files: `all-imports.html`, `paper-icon-item.html`, `paper-item-behavior.html` and `paper-item-shared-styles.html`.

If this is not very expensive in performance, I think it's a good choice.
