### PR TITLE
Corrected paper-icon-body to paper-item-body

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -109,7 +109,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </template>
     </demo-snippet>
 
-    <h3>For two-line items, use a paper-icon-body inside a paper-item or paper-icon-item</h3>
+    <h3>For two-line items, use a paper-item-body inside a paper-item or paper-icon-item</h3>
     <demo-snippet>
       <template>
         <div role="listbox">


### PR DESCRIPTION
Demo docs incorrectly stated to use a "paper-icon-body" to create multi-line paper-items.  Should say "paper-item-body."