### PR TITLE
move the button styles to an external dom-module

### DIFF
--- a/paper-item-shared-styles.html
+++ b/paper-item-shared-styles.html
@@ -16,15 +16,59 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <dom-module id="paper-item-shared-styles">
   <template>
     <style>
-      :host, .paper-item {
+      :host {
         display: block;
         position: relative;
         min-height: var(--paper-item-min-height, 48px);
         padding: 0px 16px;
       }
 
+      :host([hidden]) {
+        display: none !important;
+      }
+
+      :host(.iron-selected) {
+        font-weight: var(--paper-item-selected-weight, bold);
+
+        @apply(--paper-item-selected);
+      }
+
+      :host([disabled]) {
+        color: var(--paper-item-disabled-color, --disabled-text-color);
+
+        @apply(--paper-item-disabled);
+      }
+
+      :host(:focus) {
+        position: relative;
+        outline: 0;
+
+        @apply(--paper-item-focused);
+      }
+
+      :host(:focus):before {
+        @apply(--layout-fit);
+
+        background: currentColor;
+        content: '';
+        opacity: var(--dark-divider-opacity);
+        pointer-events: none;
+
+        @apply(--paper-item-focused-before);
+      }
+    </style>
+  </template>
+</dom-module>
+
+<dom-module id="paper-item-button-styles">
+  <template>
+    <style>
       .paper-item {
         @apply(--paper-font-subhead);
+        display: block;
+        position: relative;
+        min-height: var(--paper-item-min-height, 48px);
+        padding: 0px 16px;
         border:none;
         outline: none;
         background: white;
@@ -32,30 +76,30 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         text-align: left;
       }
 
-      :host([hidden]), .paper-item[hidden] {
+      .paper-item[hidden] {
         display: none !important;
       }
 
-      :host(.iron-selected), .paper-item.iron-selected {
+      .paper-item.iron-selected {
         font-weight: var(--paper-item-selected-weight, bold);
 
         @apply(--paper-item-selected);
       }
 
-      :host([disabled]), .paper-item[disabled] {
+      .paper-item[disabled] {
         color: var(--paper-item-disabled-color, --disabled-text-color);
 
         @apply(--paper-item-disabled);
       }
 
-      :host(:focus), .paper-item:focus {
+      .paper-item:focus {
         position: relative;
         outline: 0;
 
         @apply(--paper-item-focused);
       }
 
-      :host(:focus):before, .paper-item:focus:before {
+      .paper-item:focus:before {
         @apply(--layout-fit);
 
         background: currentColor;

--- a/paper-item.html
+++ b/paper-item.html
@@ -43,7 +43,8 @@ If you are concerned about performance and want to use `paper-item` in a `paper-
 with many items, you can just use a native `button` with the `paper-item` class
 applied (provided you have correctly included the shared styles):
 
-    <style is="custom-style" include="paper-item-shared-styles"></style>
+    <link rel="import" href="paper-item/paper-item-shared-styles.html">
+    <style is="custom-style" include="paper-item-button-styles"></style>
 
     <paper-listbox>
       <button class="paper-item" role="option">Inbox</button>


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/paper-item/issues/85.

The `host` and `.paper-item` styles can't live in the same `dom-module`, since it doesn't allow you to style a `button.paper-item` inside a `dom-module`. This fixes that. 