### PR TITLE
from polymerelements to PolymerElements in 2.0-preview

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,7 @@
     "polymer": "Polymer/polymer#^2.0.0-rc.1",
     "paper-styles": "PolymerElements/paper-styles#2.0-preview",
     "iron-flex-layout": "PolymerElements/iron-flex-layout#2.0-preview",
-    "iron-behaviors": "polymerelements/iron-behaviors#2.0-preview"
+    "iron-behaviors": "PolymerElements/iron-behaviors#2.0-preview"
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#2.0-preview",

--- a/bower.json
+++ b/bower.json
@@ -47,7 +47,7 @@
         "polymer": "Polymer/polymer#^1.1.0",
         "paper-styles": "PolymerElements/paper-styles#^1.0.0",
         "iron-flex-layout": "PolymerElements/iron-flex-layout#^1.0.0",
-        "iron-behaviors": "polymerelements/iron-behaviors#^1.0.0"
+        "iron-behaviors": "PolymerElements/iron-behaviors#^1.0.0"
       },
       "devDependencies": {
         "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",


### PR DESCRIPTION
This pull request wants to make this Polymer element consistent with the majority of other Polymer elements in the 2.0-preview branch. The uppercase version "PolymerElements" is closer to real name of the github project name, like presented in the git URL.

The use of mixed case does not seem to have an effect on bower and JavaScript projects. But other languages like Java are more picky and would benefit from consistency.

I fixed this in the  "2.0-preview" branch of this element, because it would be very nice to have this cleaned up and consistent in 2.0 release. I have manually checked 66 elements that have a "2.0-preview" branch. 56 are ok. This element is one of 10 which has these small differences.

This pull request is a manual follow up of PolymerLabs/tedium#47 and PolymerLabs/tedium#48 which try to do this in an automated way, but are stuck.