### PR TITLE
paper-icon-item: do not shrink contentIcon

### DIFF
--- a/paper-icon-item.js
+++ b/paper-icon-item.js
@@ -70,6 +70,7 @@ Polymer({
         @apply --layout-center;
 
         width: var(--paper-item-icon-width, 56px);
+        flex-shrink: 0;
         @apply --paper-item-icon;
       }
     </style>


### PR DESCRIPTION
When text in `paper-icon-item` doesn't fit one line, flex container shrinks `contentIcon` div which looks bad. This change protects width of `contentIcon`.

Before:
<img width="257" alt="Screen Shot 2020-02-12 at 12 09 27 AM" src="https://user-images.githubusercontent.com/3767331/74293934-3ae5d380-4d34-11ea-8bbd-514810395dbd.png">
Note that text is misaligned.

After:
<img width="254" alt="Screen Shot 2020-02-12 at 1 09 36 AM" src="https://user-images.githubusercontent.com/3767331/74293972-6072dd00-4d34-11ea-9654-ed764c26da48.png">

